### PR TITLE
Db on ci

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -37,7 +37,7 @@ jobs:
         run: |
           psql -h $PGUSER -U $PGPASSWORD -c "create database $PEEP_DB_NAME"
           psql -h $PGUSER -U $PGPASSWORD -c "create user $PEEP_USER"
-          psql -h $PGUSER -U $PGPASSWORD -c "alter user $PEEP_USER with password $PEEP_PASSWORD"
+          psql -h $PGUSER -U $PGPASSWORD -c "alter user $PEEP_USER with password '$PEEP_PASSWORD'"
           psql -h $PGUSER -U $PGPASSWORD -c "grant all privileges on database $PEEP_DB_NAME to $PEEP_USER"
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -31,17 +31,19 @@ jobs:
         env:
           PGUSER: postgres
           PGPASSWORD: postgres
+          PGHOST: postgres
           PEEP_DB_NAME: peep_python
           PEEP_TEST_DB_NAME: test_db
           PEEP_USER: peep_user
           PEEP_PASSWORD: peep_password
         run: |
-          psql -h $PGUSER -U $PGPASSWORD -c "create database $PEEP_DB_NAME"
-          psql -h $PGUSER -U $PGPASSWORD -c "create database $PEEP_TEST_DB_NAME"
-          psql -h $PGUSER -U $PGPASSWORD -c "create user $PEEP_USER"
-          psql -h $PGUSER -U $PGPASSWORD -c "alter user $PEEP_USER with password '$PEEP_PASSWORD'"
-          psql -h $PGUSER -U $PGPASSWORD -c "grant all privileges on database $PEEP_DB_NAME to $PEEP_USER"
-          psql -h $PGUSER -U $PGPASSWORD -c "alter database $PEEP_DB_NAME owner to $PEEP_USER"
+          psql -h $PGHOST -U $PGUSER -c "CREATE USER $PEEP_USER"
+          psql -h $PGHOST -U $PGUSER -c "ALTER USER $PEEP_USER WITH PASSWORD '$PEEP_PASSWORD'"
+          psql -h $PGHOST -U $PGUSER -c "CREATE DATABASE $PEEP_DB_NAME OWNER $PEEP_USER"
+          psql -h $PGHOST -U $PGUSER -c "CREATE DATABASE $PEEP_TEST_DB_NAME OWNER $PEEP_USER"
+          psql -h $PGHOST -U $PGUSER -c "GRANT ALL PRIVILEGES ON DATABASE $PEEP_DB_NAME TO $PEEP_USER"
+          psql -h $PGHOST -U $PGUSER PEEP_DB_NAME -c "CREATE EXTENSION IF NOT EXISTS 'uuid-ossp'"
+
       - uses: actions/checkout@v4
       - name: Set up Python
         # This is the version of the action for setting up Python, not the Python version.

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -41,7 +41,7 @@ jobs:
           psql -h $PGUSER -U $PGPASSWORD -c "create user $PEEP_USER"
           psql -h $PGUSER -U $PGPASSWORD -c "alter user $PEEP_USER with password '$PEEP_PASSWORD'"
           psql -h $PGUSER -U $PGPASSWORD -c "grant all privileges on database $PEEP_DB_NAME to $PEEP_USER"
-          psql -h $PGUSER -U $PGPASSWORD -c "alter user $PEEP_USER createdb"
+          psql -h $PGUSER -U $PGPASSWORD -c "alter database $PEEP_DB_NAME owner to $PEEP_USER"
       - uses: actions/checkout@v4
       - name: Set up Python
         # This is the version of the action for setting up Python, not the Python version.

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -20,7 +20,14 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
+
     steps:
+      - name: Create test database
+        run: |
+          psql -c "create database peep_python"
+          psql -c "create user peep_user"
+          psql -c "alter user the_user with password 'peep_password'"
+          psql -c "grant all privileges on database peep_python to peep_user"
       - uses: actions/checkout@v4
       - name: Set up Python
         # This is the version of the action for setting up Python, not the Python version.

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -3,6 +3,12 @@ name: Python workflow
 on: [ push ]
 
 jobs:
+  env:
+    PGUSER=postgres
+    PGPASSWORD=postgres
+    PEEP_DB_NAME=peep_python
+    PEEP_USER=peep_user
+    PEEP_PASSWORD=peep_password
   build:
     runs-on: ubuntu-20.04
     container: python:3.10-bullseye
@@ -12,6 +18,7 @@ jobs:
         image: postgres
         # Provide the password for postgres
         env:
+          # default postgres user and password
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
         # Set health checks to wait until postgres has started
@@ -27,12 +34,6 @@ jobs:
           apt-get update
           apt-get install --yes --no-install-recommends postgresql-client
       - name: Create test database and user
-        env:
-          PGUSER=postgres
-          PGPASSWORD=postgres
-          PEEP_DB_NAME=peep_python
-          PEEP_USER=peep_user
-          PEEP_PASSWORD=peep_password
         run: |
           psql -h $PGUSER -U $PGPASSWORD -c "create database $PEEP_DB_NAME"
           psql -h $PGUSER -U $PGPASSWORD -c "create user $PEEP_USER"

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -28,11 +28,11 @@ jobs:
           apt-get install --yes --no-install-recommends postgresql-client
       - name: Create test database and user
         env:
-          - PGUSER=postgres
-          - PGPASSWORD=postgres
-          - PEEP_DB_NAME=peep_python
-          - PEEP_USER=peep_user
-          - PEEP_PASSWORD=peep_password
+          PGUSER=postgres
+          PGPASSWORD=postgres
+          PEEP_DB_NAME=peep_python
+          PEEP_USER=peep_user
+          PEEP_PASSWORD=peep_password
         run: |
           psql -h $PGUSER -U $PGPASSWORD -c "create database $PEEP_DB_NAME"
           psql -h $PGUSER -U $PGPASSWORD -c "create user $PEEP_USER"

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -12,6 +12,7 @@ jobs:
         image: postgres
         # Provide the password for postgres
         env:
+          POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
         # Set health checks to wait until postgres has started
         options: >-

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -27,11 +27,17 @@ jobs:
           apt-get update
           apt-get install --yes --no-install-recommends postgresql-client
       - name: Create test database and user
+        env:
+          - PGUSER=postgres
+          - PGPASSWORD=postgres
+          - PEEP_DB_NAME=peep_python
+          - PEEP_USER=peep_user
+          - PEEP_PASSWORD=peep_password
         run: |
-          PGPASSWORD=postgres psql -h postgres -U postgres -c "create database peep_python"
-          PGPASSWORD=postgres psql -h postgres -U postgres -c "create user peep_user"
-          PGPASSWORD=postgres psql -h postgres -U postgres -c "alter user the_user with password 'peep_password'"
-          PGPASSWORD=postgres psql -h postgres -U postgres -c "grant all privileges on database peep_python to peep_user"
+          psql -h $PGUSER -U $PGPASSWORD -c "create database $PEEP_DB_NAME"
+          psql -h $PGUSER -U $PGPASSWORD -c "create user $PEEP_USER"
+          psql -h $PGUSER -U $PGPASSWORD -c "alter user $PEEP_USER with password $PEEP_PASSWORD"
+          psql -h $PGUSER -U $PGPASSWORD -c "grant all privileges on database $PEEP_DB_NAME to $PEEP_USER"
       - uses: actions/checkout@v4
       - name: Set up Python
         # This is the version of the action for setting up Python, not the Python version.

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -5,6 +5,20 @@ on: [ push ]
 jobs:
   build:
     runs-on: ubuntu-latest
+    container: 3.10-bullseye
+    services:
+      postgres:
+        # Docker Hub image
+        image: postgres
+        # Provide the password for postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -22,7 +22,11 @@ jobs:
           --health-retries 5
 
     steps:
-      - name: Create test database
+      - name: Install psql
+        run: |
+          apt-get update
+          apt-get install --yes --no-install-recommends postgresql-client
+      - name: Create test database and user
         run: |
           psql -c "create database peep_python"
           psql -c "create user peep_user"

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -4,7 +4,7 @@ on: [ push ]
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     container: python:3.10-bullseye
     services:
       postgres:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -3,12 +3,6 @@ name: Python workflow
 on: [ push ]
 
 jobs:
-  env:
-    PGUSER=postgres
-    PGPASSWORD=postgres
-    PEEP_DB_NAME=peep_python
-    PEEP_USER=peep_user
-    PEEP_PASSWORD=peep_password
   build:
     runs-on: ubuntu-20.04
     container: python:3.10-bullseye
@@ -34,6 +28,12 @@ jobs:
           apt-get update
           apt-get install --yes --no-install-recommends postgresql-client
       - name: Create test database and user
+        env:
+          PGUSER: postgres
+          PGPASSWORD: postgres
+          PEEP_DB_NAME: peep_python
+          PEEP_USER: peep_user
+          PEEP_PASSWORD: peep_password
         run: |
           psql -h $PGUSER -U $PGPASSWORD -c "create database $PEEP_DB_NAME"
           psql -h $PGUSER -U $PGPASSWORD -c "create user $PEEP_USER"

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           PGPASSWORD=postgres psql -h postgres -U postgres -c "create database peep_python"
           PGPASSWORD=postgres psql -h postgres -U postgres -c "create user peep_user"
-          PGPASSWORD=postgres psql -h postgres -U postgres -c 'alter user the_user with password "peep_password"'
+          PGPASSWORD=postgres psql -h postgres -U postgres -c "alter user the_user with password 'peep_password'"
           PGPASSWORD=postgres psql -h postgres -U postgres -c "grant all privileges on database peep_python to peep_user"
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -42,7 +42,9 @@ jobs:
           psql -h $PGHOST -U $PGUSER -c "CREATE DATABASE $PEEP_DB_NAME OWNER $PEEP_USER"
           psql -h $PGHOST -U $PGUSER -c "CREATE DATABASE $PEEP_TEST_DB_NAME OWNER $PEEP_USER"
           psql -h $PGHOST -U $PGUSER -c "GRANT ALL PRIVILEGES ON DATABASE $PEEP_DB_NAME TO $PEEP_USER"
+          psql -h $PGHOST -U $PGUSER -c "GRANT ALL PRIVILEGES ON DATABASE $PEEP_TEST_DB_NAME TO $PEEP_USER"
           psql -h $PGHOST -U $PGUSER $PEEP_DB_NAME -c "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\""
+          psql -h $PGHOST -U $PGUSER $PEEP_TEST_DB_NAME -c "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\""
 
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -42,7 +42,7 @@ jobs:
           psql -h $PGHOST -U $PGUSER -c "CREATE DATABASE $PEEP_DB_NAME OWNER $PEEP_USER"
           psql -h $PGHOST -U $PGUSER -c "CREATE DATABASE $PEEP_TEST_DB_NAME OWNER $PEEP_USER"
           psql -h $PGHOST -U $PGUSER -c "GRANT ALL PRIVILEGES ON DATABASE $PEEP_DB_NAME TO $PEEP_USER"
-          psql -h $PGHOST -U $PGUSER PEEP_DB_NAME -c "CREATE EXTENSION IF NOT EXISTS 'uuid-ossp'"
+          psql -h $PGHOST -U $PGUSER $PEEP_DB_NAME -c "CREATE EXTENSION IF NOT EXISTS 'uuid-ossp'"
 
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -41,6 +41,7 @@ jobs:
           psql -h $PGUSER -U $PGPASSWORD -c "create user $PEEP_USER"
           psql -h $PGUSER -U $PGPASSWORD -c "alter user $PEEP_USER with password '$PEEP_PASSWORD'"
           psql -h $PGUSER -U $PGPASSWORD -c "grant all privileges on database $PEEP_DB_NAME to $PEEP_USER"
+          psql -h $PGUSER -U $PGPASSWORD -c "alter user $PEEP_USER createdb"
       - uses: actions/checkout@v4
       - name: Set up Python
         # This is the version of the action for setting up Python, not the Python version.

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -5,7 +5,7 @@ on: [ push ]
 jobs:
   build:
     runs-on: ubuntu-latest
-    container: 3.10-bullseye
+    container: python:3.10-bullseye
     services:
       postgres:
         # Docker Hub image

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -28,10 +28,10 @@ jobs:
           apt-get install --yes --no-install-recommends postgresql-client
       - name: Create test database and user
         run: |
-          psql -h postgres -U postgres -c "create database peep_python"
-          psql -h postgres -U postgres -c "create user peep_user"
-          psql -h postgres -U postgres -c 'alter user the_user with password "peep_password"'
-          psql -h postgres -U postgres -c "grant all privileges on database peep_python to peep_user"
+          PGPASSWORD=postgres psql -h postgres -U postgres -c "create database peep_python"
+          PGPASSWORD=postgres psql -h postgres -U postgres -c "create user peep_user"
+          PGPASSWORD=postgres psql -h postgres -U postgres -c 'alter user the_user with password "peep_password"'
+          PGPASSWORD=postgres psql -h postgres -U postgres -c "grant all privileges on database peep_python to peep_user"
       - uses: actions/checkout@v4
       - name: Set up Python
         # This is the version of the action for setting up Python, not the Python version.

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -28,10 +28,10 @@ jobs:
           apt-get install --yes --no-install-recommends postgresql-client
       - name: Create test database and user
         run: |
-          psql -c "create database peep_python"
-          psql -c "create user peep_user"
-          psql -c "alter user the_user with password 'peep_password'"
-          psql -c "grant all privileges on database peep_python to peep_user"
+          psql -h postgres -U postgres -c "create database peep_python"
+          psql -h postgres -U postgres -c "create user peep_user"
+          psql -h postgres -U postgres -c 'alter user the_user with password "peep_password"'
+          psql -h postgres -U postgres -c "grant all privileges on database peep_python to peep_user"
       - uses: actions/checkout@v4
       - name: Set up Python
         # This is the version of the action for setting up Python, not the Python version.

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -42,7 +42,7 @@ jobs:
           psql -h $PGHOST -U $PGUSER -c "CREATE DATABASE $PEEP_DB_NAME OWNER $PEEP_USER"
           psql -h $PGHOST -U $PGUSER -c "CREATE DATABASE $PEEP_TEST_DB_NAME OWNER $PEEP_USER"
           psql -h $PGHOST -U $PGUSER -c "GRANT ALL PRIVILEGES ON DATABASE $PEEP_DB_NAME TO $PEEP_USER"
-          psql -h $PGHOST -U $PGUSER $PEEP_DB_NAME -c "CREATE EXTENSION IF NOT EXISTS 'uuid-ossp'"
+          psql -h $PGHOST -U $PGUSER $PEEP_DB_NAME -c "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\""
 
       - uses: actions/checkout@v4
       - name: Set up Python

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -21,34 +21,34 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-
-    steps:
-      - name: Install psql
-        run: |
-          apt-get update
-          apt-get install --yes --no-install-recommends postgresql-client
-      - name: Create test database and user
-        env:
-          PGUSER: postgres
-          PGPASSWORD: postgres
-          PEEP_DB_NAME: peep_python
-          PEEP_USER: peep_user
-          PEEP_PASSWORD: peep_password
-        run: |
-          psql -h $PGUSER -U $PGPASSWORD -c "create database $PEEP_DB_NAME"
-          psql -h $PGUSER -U $PGPASSWORD -c "create user $PEEP_USER"
-          psql -h $PGUSER -U $PGPASSWORD -c "alter user $PEEP_USER with password '$PEEP_PASSWORD'"
-          psql -h $PGUSER -U $PGPASSWORD -c "grant all privileges on database $PEEP_DB_NAME to $PEEP_USER"
-      - uses: actions/checkout@v4
-      - name: Set up Python
-        # This is the version of the action for setting up Python, not the Python version.
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-          architecture: 'x64'
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-      - name: Run unit tests
-        run: pytest lambdas/tests/
+      peep:
+        steps:
+          - name: Install psql
+            run: |
+              apt-get update
+              apt-get install --yes --no-install-recommends postgresql-client
+          - name: Create test database and user
+            env:
+              PGUSER: postgres
+              PGPASSWORD: postgres
+              PEEP_DB_NAME: peep_python
+              PEEP_USER: peep_user
+              PEEP_PASSWORD: peep_password
+            run: |
+              psql -h $PGUSER -U $PGPASSWORD -c "create database $PEEP_DB_NAME"
+              psql -h $PGUSER -U $PGPASSWORD -c "create user $PEEP_USER"
+              psql -h $PGUSER -U $PGPASSWORD -c "alter user $PEEP_USER with password '$PEEP_PASSWORD'"
+              psql -h $PGUSER -U $PGPASSWORD -c "grant all privileges on database $PEEP_DB_NAME to $PEEP_USER"
+          - uses: actions/checkout@v4
+          - name: Set up Python
+            # This is the version of the action for setting up Python, not the Python version.
+            uses: actions/setup-python@v5
+            with:
+              python-version: '3.10'
+              architecture: 'x64'
+          - name: Install dependencies
+            run: |
+              python -m pip install --upgrade pip
+              pip install -r requirements.txt
+          - name: Run unit tests
+            run: pytest lambdas/tests/

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -21,34 +21,36 @@ jobs:
           --health-interval 10s
           --health-timeout 5s
           --health-retries 5
-      peep:
-        steps:
-          - name: Install psql
-            run: |
-              apt-get update
-              apt-get install --yes --no-install-recommends postgresql-client
-          - name: Create test database and user
-            env:
-              PGUSER: postgres
-              PGPASSWORD: postgres
-              PEEP_DB_NAME: peep_python
-              PEEP_USER: peep_user
-              PEEP_PASSWORD: peep_password
-            run: |
-              psql -h $PGUSER -U $PGPASSWORD -c "create database $PEEP_DB_NAME"
-              psql -h $PGUSER -U $PGPASSWORD -c "create user $PEEP_USER"
-              psql -h $PGUSER -U $PGPASSWORD -c "alter user $PEEP_USER with password '$PEEP_PASSWORD'"
-              psql -h $PGUSER -U $PGPASSWORD -c "grant all privileges on database $PEEP_DB_NAME to $PEEP_USER"
-          - uses: actions/checkout@v4
-          - name: Set up Python
-            # This is the version of the action for setting up Python, not the Python version.
-            uses: actions/setup-python@v5
-            with:
-              python-version: '3.10'
-              architecture: 'x64'
-          - name: Install dependencies
-            run: |
-              python -m pip install --upgrade pip
-              pip install -r requirements.txt
-          - name: Run unit tests
-            run: pytest lambdas/tests/
+
+    steps:
+      - name: Install psql
+        run: |
+          apt-get update
+          apt-get install --yes --no-install-recommends postgresql-client
+      - name: Create test database and user
+        env:
+          PGUSER: postgres
+          PGPASSWORD: postgres
+          PEEP_DB_NAME: peep_python
+          PEEP_TEST_DB_NAME: test_db
+          PEEP_USER: peep_user
+          PEEP_PASSWORD: peep_password
+        run: |
+          psql -h $PGUSER -U $PGPASSWORD -c "create database $PEEP_DB_NAME"
+          psql -h $PGUSER -U $PGPASSWORD -c "create database $PEEP_TEST_DB_NAME"
+          psql -h $PGUSER -U $PGPASSWORD -c "create user $PEEP_USER"
+          psql -h $PGUSER -U $PGPASSWORD -c "alter user $PEEP_USER with password '$PEEP_PASSWORD'"
+          psql -h $PGUSER -U $PGPASSWORD -c "grant all privileges on database $PEEP_DB_NAME to $PEEP_USER"
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        # This is the version of the action for setting up Python, not the Python version.
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+          architecture: 'x64'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run unit tests
+        run: pytest lambdas/tests/

--- a/lambdas/db/main.py
+++ b/lambdas/db/main.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Mapped, mapped_column, scoped_session, sessionmaker
 
 # Create a global engine and session factory
-DATABASE_URL = 'postgresql+psycopg2://postgres:postgres@localhost/postgres'
+DATABASE_URL = 'postgresql+psycopg2://peep_user:peep_password@localhost/peep_python'
 
 # Create the SQLAlchemy engine
 engine = create_engine(DATABASE_URL, pool_pre_ping=True, echo=True)

--- a/lambdas/db/main.py
+++ b/lambdas/db/main.py
@@ -6,7 +6,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Mapped, mapped_column, scoped_session, sessionmaker
 
 # Create a global engine and session factory
-DATABASE_URL = 'postgresql+psycopg2://peep_user:peep_password@localhost/peep_python'
+DATABASE_URL = 'postgresql+psycopg2://peep_user:peep_password@postgres/peep_python'
 
 # Create the SQLAlchemy engine
 engine = create_engine(DATABASE_URL, pool_pre_ping=True, echo=True)

--- a/lambdas/db/main.py
+++ b/lambdas/db/main.py
@@ -6,6 +6,8 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import Mapped, mapped_column, scoped_session, sessionmaker
 
 # Create a global engine and session factory
+# On the GitHub actions CI, the hostname of the service container for the database is the label. Since in our workflow
+# the service is named "postgres", the hostname here must also be "postgres"
 DATABASE_URL = 'postgresql+psycopg2://peep_user:peep_password@postgres/peep_python'
 
 # Create the SQLAlchemy engine

--- a/lambdas/db/main.py
+++ b/lambdas/db/main.py
@@ -1,13 +1,12 @@
 from datetime import datetime
 
-from sqlalchemy import create_engine
-from sqlalchemy import func
+from sqlalchemy import create_engine, func
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker, scoped_session, Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, scoped_session, sessionmaker
 
 # Create a global engine and session factory
-DATABASE_URL = 'postgresql+psycopg2://peep_user:peep_password@localhost/peep_python'
+DATABASE_URL = 'postgresql+psycopg2://postgres:postgres@localhost/postgres'
 
 # Create the SQLAlchemy engine
 engine = create_engine(DATABASE_URL, pool_pre_ping=True, echo=True)


### PR DESCRIPTION
Fix for [Issue 7](https://github.com/leolas95/peep-python/issues/7).

It:
- Installs a Postgres as a service container in the CI environment
- Installs `psql` so we can issue commands
- Creates the test db, user and grants necessary permissions
- Installs the `uuid-ossp` extension so we can use `uuid_generate_v4()`

---
TODOs for later:
- Put all of the sensitive stuff (PGPASSWORD, PGUSER, PGHOST, PEEP_PASSWORD, etc.) into external environment files/variables that we can refer, so we don't hardcode them in the workflow file.
- Same but for the code: currently the DB url is hardcoded

Issue to work on that: https://github.com/leolas95/peep-python/issues/9