### PR TITLE
Add missing bcrypt dep that makes lambda fail

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ sqlalchemy==2.0.36
 # We might need to build from source
 psycopg2-binary==2.9.10
 pyjwt==2.10.0
-passlib==1.7.4
+passlib[bcrypt]==1.7.4
 httpx==0.27.2
 pytest==8.3.3
 python-dotenv==1.0.1


### PR DESCRIPTION
We were missing the specific `bcrypt` package when using Passlib, so the Lambda failed when hashing the password of a new user.