### PR TITLE
Use `bcrypt` directly and remove `passlib`

### DIFF
--- a/cdk/cdk/cdk_stack.py
+++ b/cdk/cdk/cdk_stack.py
@@ -1,13 +1,13 @@
 import os.path
 
-from aws_cdk import (CfnOutput, Fn, Stack, aws_apigateway as apigw, aws_ec2 as ec2,
+from aws_cdk import (CfnOutput, Duration, Fn, Stack, aws_apigateway as apigw, aws_ec2 as ec2,
                      aws_lambda as lambda_)
 from constructs import Construct
 from dotenv import load_dotenv
 
 dirname = os.path.dirname(__file__)
 
-load_dotenv(dotenv_path='../../.env')
+load_dotenv(dotenv_path='../.env')
 
 
 # class PeepStack(Stack):
@@ -95,6 +95,7 @@ class PeepStack(Stack):
             'vpc': vpc,
             'vpc_subnets': ec2.SubnetSelection(subnets=[private_subnet_us_east_1a]),
             'security_groups': [lambda_sg],
+            'timeout': Duration.seconds(30)
         }
         proxy_lambda = lambda_.Function(self, 'ProxyLambda', **proxy_lambda_kwargs)
         proxy_lambda.node.add_dependency(private_subnet_us_east_1a)

--- a/lambdas/tests/routes/users/test_users.py
+++ b/lambdas/tests/routes/users/test_users.py
@@ -1,5 +1,3 @@
-import json
-
 from fastapi import status
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
@@ -17,9 +15,9 @@ def test_create_user(client: TestClient, session_fixture: Session):
         "/users/auth/signup/",
         json=body
     )
+
+    assert response.status_code == status.HTTP_201_CREATED
     assert response.content is not None
-    parsed_body = json.loads(response.content)
-    assert parsed_body['statusCode'] == status.HTTP_201_CREATED
 
 
 def test_update_user(client: TestClient, session_fixture: Session):

--- a/lambdas/tests/routes/users/test_users.py
+++ b/lambdas/tests/routes/users/test_users.py
@@ -1,3 +1,5 @@
+import json
+
 from fastapi import status
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session
@@ -15,7 +17,9 @@ def test_create_user(client: TestClient, session_fixture: Session):
         "/users/auth/signup/",
         json=body
     )
-    assert response.status_code == status.HTTP_201_CREATED
+    assert response.content is not None
+    parsed_body = json.loads(response.content)
+    assert parsed_body['statusCode'] == status.HTTP_201_CREATED
 
 
 def test_update_user(client: TestClient, session_fixture: Session):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ sqlalchemy==2.0.36
 # We might need to build from source
 psycopg2-binary==2.9.10
 pyjwt==2.10.0
-passlib[bcrypt]==1.7.4
+bcrypt==4.2.1
 httpx==0.27.2
 pytest==8.3.3
 python-dotenv==1.0.1


### PR DESCRIPTION
We were having a weird issue using Passlib on live, as it it couldn't read the `bcrypt` version.

See the thread: https://github.com/pyca/bcrypt/issues/684

I removed `passlib` so now we directly use `bcrypt` instead.

I also increased the lambda timeout to 30 seconds.