### PR TITLE
Ignore __pycache__ directory on deployment package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ PIP_OPTS =  --requirement $(REQUIREMENT_FILE) \
 			--only-binary=:all: \
 			--upgrade $(UPGRADE_OPTS)
 
-ZIP_COMMON_OPTS = -x "*.DS_Store" -x "**/__pycache__/*" -x "__pycache__/"
+ZIP_COMMON_OPTS = -x "*.DS_Store" -x "__pycache__/*" -x "**/__pycache__/*"
 
 # .zip to be uploaded
 DEPLOYMENT_PACKAGE = deployment_package.zip


### PR DESCRIPTION
This solves #29, where the `__pycache__` directory was being included in the final .zip.

For some reason I couldn't configure `pip` to _not generate `__pycache__`_ in the first place; I tried using `PYTHONDONTWRITEBYTECODE=1 pip install $(PIP_OPTS)` and `PYTHONPYCACHEPREFIX="/dev/null" pip install $(PIP_OPTS)` on the "Installing deps" step and none of them worked.

So in the end I just excluded them from the zip packaging.