### PR TITLE
Cache dependencies on pipeline

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -51,13 +51,6 @@ jobs:
           python-version: '3.10'
           architecture: 'x64'
 
-      - name: Install dependencies
-        run: |
-          chown -R $(whoami) /github/home
-          python -m ensurepip --upgrade
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
-
       - name: Cache pip dependencies
         uses: actions/cache@v4
         with:
@@ -65,6 +58,13 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
+
+      - name: Install dependencies
+        run: |
+          chown -R $(whoami) /github/home
+          python -m ensurepip --upgrade
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
 
       - name: Run tests
         env:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -59,12 +59,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
+      - name: Ensure pip is installed and cache directory available
+        run: |
+          python -m ensurepip --upgrade
+          python -m pip install --upgrade pip --root-user-action option
+          chown -R $(whoami) /github/home
+
       - name: Install dependencies
         run: |
-          chown -R $(whoami) /github/home
-          python -m ensurepip --upgrade
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
+          python -m pip install -r requirements.txt --root-user-action option
 
       - name: Run tests
         env:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -44,25 +44,25 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - name: Install lsb_release to enable caching
-        run: |
-          apt-get install --yes --no-install-recommends lsb-release
-
-      - name: Install pip
-        run: |
-          python -m ensurepip --upgrade
-          python -m pip install --upgrade pip
-
       - name: Set up Python
         # This is not the python version, it's the GitHub action version
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           architecture: 'x64'
-          cache: 'pip'
+
+      - name: Cache pip dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+          restore-keys: |
+            ${{ runner.os }}-pip-
 
       - name: Install dependencies
         run: |
+          python -m ensurepip --upgrade
+          python -m pip install --upgrade pip
           python -m pip install -r requirements.txt
 
       - name: Run tests

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -49,6 +49,7 @@ jobs:
         with:
           python-version: '3.10'
           architecture: 'x64'
+          cache: 'pip'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -44,6 +44,12 @@ jobs:
 
       - uses: actions/checkout@v4
       - name: Set up Python
+
+      - name: Install lsb_release to enable caching
+        run: |
+          apt-get update
+          apt-get install --yes --no-install-recommends lsb-release
+
         # This is not the python version, it's the GitHub action version
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -53,6 +53,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo chown -R $(whoami) /github/home
           python -m ensurepip --upgrade
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -43,13 +43,13 @@ jobs:
           psql -h $PGHOST -U $PGUSER $PEEP_TEST_DB_NAME -c "CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\""
 
       - uses: actions/checkout@v4
-      - name: Set up Python
 
       - name: Install lsb_release to enable caching
         run: |
           apt-get update
           apt-get install --yes --no-install-recommends lsb-release
 
+      - name: Set up Python
         # This is not the python version, it's the GitHub action version
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -62,12 +62,12 @@ jobs:
       - name: Ensure pip is installed and cache directory available
         run: |
           python -m ensurepip --upgrade
-          python -m pip install --upgrade pip --root-user-action option
+          python -m pip install --upgrade pip --root-user-action option=ignore
           chown -R $(whoami) /github/home
 
       - name: Install dependencies
         run: |
-          python -m pip install -r requirements.txt --root-user-action option
+          python -m pip install -r requirements.txt --root-user-action option=ignore
 
       - name: Run tests
         env:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -50,16 +50,21 @@ jobs:
 
       - name: Set up Python
         # This is not the python version, it's the GitHub action version
-        run: |
-          python -m ensurepip --upgrade
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           architecture: 'x64'
           cache: 'pip'
+
+      - name: Install pip
+        run: |
+          python -m ensurepip --upgrade
+          python -m pip install --upgrade pip
+
       - name: Install dependencies
         run: |
-          pip install -r requirements.txt
+          python -m pip install -r requirements.txt
+
       - name: Run tests
         env:
           PEEP_ENV: ${{ vars.PEEP_ENV }}

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -51,7 +51,7 @@ jobs:
           python-version: '3.10'
           architecture: 'x64'
 
-      - name: Setup cache
+      - name: Set up cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -51,7 +51,7 @@ jobs:
           python-version: '3.10'
           architecture: 'x64'
 
-      - name: Cache pip dependencies
+      - name: Setup cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/pip
@@ -59,15 +59,15 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pip-
 
-      - name: Ensure pip is installed and cache directory available
+      - name: Install pip and give permissions to the path of cache
         run: |
+          chown -R $(whoami) /github/home # Ensure the directory where ~/.cache/pip is located is owned by the current user
           python -m ensurepip --upgrade
-          python -m pip install --upgrade pip --root-user-action option=ignore
-          chown -R $(whoami) /github/home
+          python -m pip install --upgrade pip
 
       - name: Install dependencies
         run: |
-          python -m pip install -r requirements.txt --root-user-action option=ignore
+          python -m pip install -r requirements.txt
 
       - name: Run tests
         env:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -46,11 +46,12 @@ jobs:
 
       - name: Install lsb_release to enable caching
         run: |
-          apt-get update
           apt-get install --yes --no-install-recommends lsb-release
 
       - name: Set up Python
         # This is not the python version, it's the GitHub action version
+        run: |
+          python -m ensurepip --upgrade
         uses: actions/setup-python@v5
         with:
           python-version: '3.10'
@@ -58,7 +59,6 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
           pip install -r requirements.txt
       - name: Run tests
         env:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -48,6 +48,11 @@ jobs:
         run: |
           apt-get install --yes --no-install-recommends lsb-release
 
+      - name: Install pip
+        run: |
+          python -m ensurepip --upgrade
+          python -m pip install --upgrade pip
+
       - name: Set up Python
         # This is not the python version, it's the GitHub action version
         uses: actions/setup-python@v5
@@ -55,11 +60,6 @@ jobs:
           python-version: '3.10'
           architecture: 'x64'
           cache: 'pip'
-
-      - name: Install pip
-        run: |
-          python -m ensurepip --upgrade
-          python -m pip install --upgrade pip
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -51,6 +51,12 @@ jobs:
           python-version: '3.10'
           architecture: 'x64'
 
+      - name: Install dependencies
+        run: |
+          python -m ensurepip --upgrade
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
       - name: Cache pip dependencies
         uses: actions/cache@v4
         with:
@@ -58,12 +64,6 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
-
-      - name: Install dependencies
-        run: |
-          python -m ensurepip --upgrade
-          python -m pip install --upgrade pip
-          python -m pip install -r requirements.txt
 
       - name: Run tests
         env:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          sudo chown -R $(whoami) /github/home
+          chown -R $(whoami) /github/home
           python -m ensurepip --upgrade
           python -m pip install --upgrade pip
           python -m pip install -r requirements.txt


### PR DESCRIPTION
This addresses #13.

The `pip` dependencies are cached using a hash of the `requirements.txt` file. If there's a cache hit, now we used the cached deps instead of downloading them everytime.