### PR TITLE
Add secrets management

### DIFF
--- a/cdk/cdk/cdk_stack.py
+++ b/cdk/cdk/cdk_stack.py
@@ -94,8 +94,6 @@ class PeepStack(Stack):
             'architecture': lambda_.Architecture.ARM_64,
             'environment': {
                 'PEEP_ENV': os.getenv('PEEP_ENV'),
-                # 'DB_USER': os.getenv('DB_USER'),
-                # 'DB_PASSWORD': os.getenv('DB_PASSWORD'),
                 'DB_HOST': rds_instance_endpoint,
                 'DB_PORT': os.getenv('DB_PORT'),
                 'DB_NAME': os.getenv('DB_NAME')
@@ -109,9 +107,9 @@ class PeepStack(Stack):
         proxy_lambda = lambda_.Function(self, 'ProxyLambda', **proxy_lambda_kwargs)
         proxy_lambda.node.add_dependency(private_subnet_us_east_1a)
 
-        db_user = ssm.StringParameter.from_string_parameter_name(self, 'DBUserParameter', '/peep/live/db-user')
+        db_user = ssm.StringParameter.from_string_parameter_name(self, 'DBUser', '/peep/live/db-user')
         db_user.grant_read(proxy_lambda)
-        db_password = ssm.StringParameter.from_string_parameter_name(self, 'DBPasswordParameter',
+        db_password = ssm.StringParameter.from_string_parameter_name(self, 'DBPassword',
                                                                      '/peep/live/db-password')
         db_password.grant_read(proxy_lambda)
 

--- a/lambdas/db/main.py
+++ b/lambdas/db/main.py
@@ -1,3 +1,4 @@
+import logging
 import os
 
 import boto3
@@ -5,7 +6,13 @@ from dotenv import load_dotenv
 from sqlalchemy import create_engine, text
 from sqlalchemy.orm import scoped_session, sessionmaker
 
+logger = logging.getLogger()
+logger.setLevel("INFO")
+
 from .models import Base
+
+DB_ENGINE = 'postgresql'
+DB_DRIVER = 'psycopg2'
 
 
 class DBConfigException(Exception):
@@ -22,28 +29,33 @@ class DBConfigException(Exception):
 def get_db_url():
     current_env = os.environ.get('PEEP_ENV')
     if not current_env:
+        logger.error('PEEP_ENV environment variable is not set')
         raise DBConfigException('PEEP_ENV environment variable is not set')
 
     # Only for local development and test we use .env files. Other envs (ci, live) use managed secrets
     if current_env in ('local', 'test'):
         env_file = '.env.test' if current_env == 'test' else '.env'
+        logger.info(f'Retrieving DB credentials from env file {env_file}')
 
         load_dotenv(env_file, verbose=True)
         user = os.environ.get('DB_USER')
         password = os.environ.get('DB_PASSWORD')
     else:
+        logger.info('Retrieving DB credentials from Parameter Store')
         ssm = boto3.client('ssm')
-        response = ssm.get_parameter(
-            Name=f'/project/{current_env}/db-user',
-        )
-        user = response['Parameter']['Value']
 
-        response = ssm.get_parameter(
-            Name=f'/project/{current_env}/db-password',
-        )
+        response = ssm.get_parameter(Name=f'/peep/{current_env}/db-user')
+        user = response['Parameter']['Value']
+        logger.info('found user param')
+
+        response = ssm.get_parameter(Name=f'/peep/{current_env}/db-password')
         password = response['Parameter']['Value']
+        logger.info('found password param')
+
+        logger.info('DB credentials retrieved successfully')
 
     if not user or not password:
+        logger.error('Could not retrieve DB credentials for user and password')
         raise DBConfigException(
             'DB_USER and DB_PASSWORD environment variables not set, or values not found in Parameter Store')
 
@@ -51,7 +63,8 @@ def get_db_url():
     port = os.environ.get('DB_PORT')
     db_name = os.environ.get('DB_NAME')
 
-    return f'postgresql+psycopg2://{user}:{password}@{host}:{port}/{db_name}'
+    logger.info('Connecting to database')
+    return f'{DB_ENGINE}+{DB_DRIVER}://{user}:{password}@{host}:{port}/{db_name}'
 
 
 # Create the SQLAlchemy engine

--- a/lambdas/db/main.py
+++ b/lambdas/db/main.py
@@ -40,6 +40,10 @@ def get_db_url():
         load_dotenv(env_file, verbose=True)
         user = os.environ.get('DB_USER')
         password = os.environ.get('DB_PASSWORD')
+    elif current_env == 'ci':
+        # CI environment has the DB credentials stored as secrets, and injected as environment variables
+        user = os.environ.get('DB_USER')
+        password = os.environ.get('DB_PASSWORD')
     else:
         logger.info('Retrieving DB credentials from Parameter Store')
         ssm = boto3.client('ssm')

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,4 +9,4 @@ httpx==0.27.2
 pytest==8.3.3
 python-dotenv==1.0.1
 mangum
-# boto3==1.35.55
+boto3==1.35.55


### PR DESCRIPTION
This is an initial approach to #11 and #28. For now only the DB credentials are stored in SSM Parameter Store. Other non-sensitive things like `PEEP_ENV`, `DB_PORT` and `DB_NAME` are still retrieved from the environment variables (injected by the CI).